### PR TITLE
Update license link

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         Copyright &copy; 2018 <a href="https://twitter.com/RemoHJansen">Remo H. Jansen</a>.
         Code licensed under 
         <a
-            href="https://github.com/remojansen/TSPL/blob/master/LICENSE"
+            href="https://github.com/remojansen/TechLadderIO/blob/master/LICENSE"
         >MIT</a>.
     </div>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>


### PR DESCRIPTION
The project has been renamed but the link is still pointing to the old repo. GitHub redirects the visitor to the new repo, but it should be updated 😄 